### PR TITLE
Update paginated link query mappings to return PaginatedResponse instead of List

### DIFF
--- a/api/src/main/java/com/linktreeclone/api/controller/LinkController.java
+++ b/api/src/main/java/com/linktreeclone/api/controller/LinkController.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -24,6 +25,7 @@ import com.linktreeclone.api.model.Link;
 import com.linktreeclone.api.model.User;
 import com.linktreeclone.api.payload.request.PaginatedRequest;
 import com.linktreeclone.api.payload.request.SortedPaginatedRequest;
+import com.linktreeclone.api.payload.response.PaginatedResponse;
 import com.linktreeclone.api.repository.UserRepository;
 import com.linktreeclone.api.security.service.UserDetailsImpl;
 import com.linktreeclone.api.service.LinkService;
@@ -59,26 +61,34 @@ public class LinkController {
     }
     
     @GetMapping(path = "/links/paginated")
-    public ResponseEntity<List<Link>> getPaginatedLinksByCreatorId(
+    public ResponseEntity<PaginatedResponse<Link>> getPaginatedLinksByCreatorId(
         @AuthenticationPrincipal UserDetailsImpl userDetails,
         @Valid @NotNull @RequestParam(defaultValue = "5") String pageCount,
         @Valid @NotNull @RequestParam(defaultValue = "1") String pageNumber
     ) {
         PaginatedRequest paginatedRequest = new PaginatedRequest(pageCount, pageNumber);
         Long creatorId = userDetails.getId();
-        List<Link> links = linkService.selectPaginatedLinksByCreatorId(
+
+        Page<Link> links = linkService.selectPaginatedLinksByCreatorId(
             creatorId, 
             paginatedRequest.getPageCount(), 
             paginatedRequest.getPageNumber()
         );
-        return new ResponseEntity<List<Link>>(
-            links, 
+        
+        int totalPage = links.getTotalPages();
+
+        return new ResponseEntity<PaginatedResponse<Link>>(
+            new PaginatedResponse<Link>(
+                totalPage,
+                paginatedRequest.getPageNumber(),
+                links.getContent()
+            ), 
             HttpStatus.OK
         );
     }
 
     @GetMapping("/links/paginated_sorted")
-    public ResponseEntity<List<Link>> getPaginatedSortedLinksByCreatorId(
+    public ResponseEntity<PaginatedResponse<Link>> getPaginatedSortedLinksByCreatorId(
         @Valid @NotNull @RequestParam(defaultValue = "5") String pageCount,
         @Valid @NotNull @RequestParam(defaultValue = "1") String pageNumber,
         @Valid @NotNull @RequestParam String sortKey,
@@ -92,15 +102,23 @@ public class LinkController {
             sortKey
         );
         Long creatorId = userDetails.getId();
-        List<Link> links = linkService.selectPaginatedSortedLinksByCreatorId(
+        
+        Page<Link> links = linkService.selectPaginatedSortedLinksByCreatorId(
             creatorId, 
             paginatedRequest.getPageCount(), 
             paginatedRequest.getPageNumber(),
             paginatedRequest.getSortKey(),
             paginatedRequest.getOrder()
         );
-        return new ResponseEntity<List<Link>>(
-            links, 
+
+        int totalPage = links.getTotalPages();
+
+        return new ResponseEntity<PaginatedResponse<Link>>(
+            new PaginatedResponse<Link>(
+                totalPage,
+                paginatedRequest.getPageNumber(),
+                links.getContent()
+            ), 
             HttpStatus.OK
         );
     }

--- a/api/src/main/java/com/linktreeclone/api/controller/LinkController.java
+++ b/api/src/main/java/com/linktreeclone/api/controller/LinkController.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.linktreeclone.api.exception.NotFoundException;
@@ -56,11 +58,13 @@ public class LinkController {
         );
     }
     
-    @PostMapping(path = "/links/paginated")
+    @GetMapping(path = "/links/paginated")
     public ResponseEntity<List<Link>> getPaginatedLinksByCreatorId(
         @AuthenticationPrincipal UserDetailsImpl userDetails,
-        @Valid @NotNull @RequestBody PaginatedRequest paginatedRequest
+        @Valid @NotNull @RequestParam(defaultValue = "5") String pageCount,
+        @Valid @NotNull @RequestParam(defaultValue = "1") String pageNumber
     ) {
+        PaginatedRequest paginatedRequest = new PaginatedRequest(pageCount, pageNumber);
         Long creatorId = userDetails.getId();
         List<Link> links = linkService.selectPaginatedLinksByCreatorId(
             creatorId, 
@@ -73,11 +77,20 @@ public class LinkController {
         );
     }
 
-    @PostMapping("/links/paginated_sorted")
+    @GetMapping("/links/paginated_sorted")
     public ResponseEntity<List<Link>> getPaginatedSortedLinksByCreatorId(
-        @Valid @NotNull @RequestBody SortedPaginatedRequest paginatedRequest,
+        @Valid @NotNull @RequestParam(defaultValue = "5") String pageCount,
+        @Valid @NotNull @RequestParam(defaultValue = "1") String pageNumber,
+        @Valid @NotNull @RequestParam String sortKey,
+        @Valid @NotNull @RequestParam Direction order,
         @AuthenticationPrincipal UserDetailsImpl userDetails
     ) {
+        SortedPaginatedRequest paginatedRequest = new SortedPaginatedRequest(
+            pageCount,
+            pageNumber,
+            order,
+            sortKey
+        );
         Long creatorId = userDetails.getId();
         List<Link> links = linkService.selectPaginatedSortedLinksByCreatorId(
             creatorId, 

--- a/api/src/main/java/com/linktreeclone/api/controller/LinkController.java
+++ b/api/src/main/java/com/linktreeclone/api/controller/LinkController.java
@@ -56,7 +56,7 @@ public class LinkController {
         );
     }
     
-    @GetMapping(path = "/links/paginated")
+    @PostMapping(path = "/links/paginated")
     public ResponseEntity<List<Link>> getPaginatedLinksByCreatorId(
         @AuthenticationPrincipal UserDetailsImpl userDetails,
         @Valid @NotNull @RequestBody PaginatedRequest paginatedRequest
@@ -73,7 +73,7 @@ public class LinkController {
         );
     }
 
-    @GetMapping("/links/paginated_sorted")
+    @PostMapping("/links/paginated_sorted")
     public ResponseEntity<List<Link>> getPaginatedSortedLinksByCreatorId(
         @Valid @NotNull @RequestBody SortedPaginatedRequest paginatedRequest,
         @AuthenticationPrincipal UserDetailsImpl userDetails

--- a/api/src/main/java/com/linktreeclone/api/dao/LinkDao.java
+++ b/api/src/main/java/com/linktreeclone/api/dao/LinkDao.java
@@ -3,6 +3,7 @@ package com.linktreeclone.api.dao;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Sort.Direction;
 
 import com.linktreeclone.api.model.Link;
@@ -19,7 +20,7 @@ public interface LinkDao {
 
     Optional<Link> updateLinkById(Long id, Link newLink);
 
-    List<Link> selectPaginatedLinksByCreatorId(Long creatorId, int pageCount, int pageNumber);
+    Page<Link> selectPaginatedLinksByCreatorId(Long creatorId, int pageCount, int pageNumber);
 
-    List<Link> selectPaginatedSortedLinksByCreatorId(Long creatorId, int pageCount, int pageNumber, String sortBy, Direction order);
+    Page<Link> selectPaginatedSortedLinksByCreatorId(Long creatorId, int pageCount, int pageNumber, String sortBy, Direction order);
 }

--- a/api/src/main/java/com/linktreeclone/api/dao/LinkDaoPostgresImpl.java
+++ b/api/src/main/java/com/linktreeclone/api/dao/LinkDaoPostgresImpl.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort.Direction;
@@ -61,7 +62,7 @@ public class LinkDaoPostgresImpl implements LinkDao {
     }
 
     @Override
-    public List<Link> selectPaginatedLinksByCreatorId(
+    public Page<Link> selectPaginatedLinksByCreatorId(
         Long creatorId, 
         int pageCount, 
         int pageNumber
@@ -71,7 +72,7 @@ public class LinkDaoPostgresImpl implements LinkDao {
     }
 
     @Override
-    public List<Link> selectPaginatedSortedLinksByCreatorId(
+    public Page<Link> selectPaginatedSortedLinksByCreatorId(
         Long creatorId, 
         int pageCount, 
         int pageNumber,

--- a/api/src/main/java/com/linktreeclone/api/payload/request/SortedPaginatedRequest.java
+++ b/api/src/main/java/com/linktreeclone/api/payload/request/SortedPaginatedRequest.java
@@ -14,7 +14,13 @@ public class SortedPaginatedRequest extends PaginatedRequest {
 
     public SortedPaginatedRequest() {};
 
-    public SortedPaginatedRequest(Direction order, String sortKey) {
+    public SortedPaginatedRequest(
+        String pageCount, 
+        String pageNumber, 
+        Direction order, 
+        String sortKey
+    ) {
+        super(pageCount, pageNumber);
         this.order = order;
         this.sortKey = sortKey;
     }

--- a/api/src/main/java/com/linktreeclone/api/payload/response/PaginatedResponse.java
+++ b/api/src/main/java/com/linktreeclone/api/payload/response/PaginatedResponse.java
@@ -1,0 +1,43 @@
+package com.linktreeclone.api.payload.response;
+
+import java.util.List;
+
+public class PaginatedResponse<T> {
+    private int totalPages;
+
+    private int currentPage;
+
+    private List<T> data;
+
+    public PaginatedResponse() {}
+
+    public PaginatedResponse(int totalPages, int currentPage, List<T> data) {
+        this.totalPages = totalPages;
+        this.currentPage = currentPage;
+        this.data = data;
+    }
+
+    public int getTotalPages() {
+        return this.totalPages;
+    }
+
+    public void setTotalPages(int totalPages) {
+        this.totalPages = totalPages;
+    }
+
+    public int getCurrentPage() {
+        return this.currentPage;
+    }
+
+    public void setCurrentPage(int currentPage) {
+        this.currentPage = currentPage;
+    }
+
+    public List<T> getData() {
+        return this.data;
+    }
+
+    public void setData(List<T> data) {
+        this.data = data;
+    }
+}

--- a/api/src/main/java/com/linktreeclone/api/repository/LinkRepository.java
+++ b/api/src/main/java/com/linktreeclone/api/repository/LinkRepository.java
@@ -2,6 +2,7 @@ package com.linktreeclone.api.repository;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -12,7 +13,9 @@ import jakarta.transaction.Transactional;
 public interface LinkRepository extends JpaRepository<Link, Long>  {
     List<Link> findAllByCreatorId(Long creatorId);
 
-    List<Link> findAllByCreatorId(Long creatorId, Pageable page);
+    //List<Link> findAllByCreatorId(Long creatorId, Pageable page);
+
+    Page<Link> findAllByCreatorId(Long creatorId, Pageable page);
 
     @Transactional
     void deleteByCreatorId(Long creatorId);

--- a/api/src/main/java/com/linktreeclone/api/service/LinkService.java
+++ b/api/src/main/java/com/linktreeclone/api/service/LinkService.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.stereotype.Service;
 
@@ -41,7 +42,7 @@ public class LinkService {
         return linkDao.updateLinkById(id, newLink);
     }
 
-    public List<Link> selectPaginatedLinksByCreatorId(
+    public Page<Link> selectPaginatedLinksByCreatorId(
         Long creatorId, 
         int pageCount, 
         int pageNumber
@@ -49,7 +50,7 @@ public class LinkService {
         return linkDao.selectPaginatedLinksByCreatorId(creatorId, pageCount, pageNumber);
     }
 
-    public List<Link> selectPaginatedSortedLinksByCreatorId(
+    public Page<Link> selectPaginatedSortedLinksByCreatorId(
         Long creatorId, 
         int pageCount, 
         int pageNumber,


### PR DESCRIPTION
- Create a class called PaginatedResponse that contains the number of total pages, the current page, and the paginated data
- Update paginated query mappings in LinkController to return PaginatedReponse<Link> instead of List<Link>